### PR TITLE
Rewrite rules for IIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If, however, you are cloning from GitHub or downloading the release zip file, yo
 * Unpack the downloaded code zip archive.
 * Place the contents of the /public directory inside your document root.
 * All other directories should be placed outside of the document root and not accessible via a web browser (look at the above diagram to see the structure).
-* The mod_rewrite module (if using apache server) or ISAPI_Rewrite module (if using IIS) will need to be enabled in 
+* The mod_rewrite module (if using apache server) or [URL Rewrite](http://www.iis.net/downloads/microsoft/url-rewrite) module (if using IIS) will need to be enabled in 
 your server configuration.
 * Create a MySQL database called 'simple-quiz'
 * Import simple-quiz.sql into MySQL using a tool like phpmyadmin or using the MySQL 'source' command.

--- a/public/web.config
+++ b/public/web.config
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer>
+        <rewrite>
+            <rules>
+                <rule name="Index rewriting" stopProcessing="true">
+                    <match url="^" ignoreCase="false" />
+                    <conditions logicalGrouping="MatchAll">
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
+                    </conditions>
+                    <action type="Rewrite" url="index.php" appendQueryString="true" />
+                </rule>
+            </rules>
+        </rewrite>
+    </system.webServer>
+</configuration>


### PR DESCRIPTION
You mention ISAPI_Rewrite in your readme, however there is official URL Rewrite module already available in newer IIS, which is IMO better (mostly because it's 100% free), however does not parse .htaccess files directly.

I have imported rules from .htaccess to web.config file for IIS, and also changed documentation to mention URL Rewrite for IIS instead of ISAPI_Rewrite.

Have some relation with #14.