### PR TITLE
Fix session warning in PHP 7.1

### DIFF
--- a/SimpleQuiz/Utils/Session.php
+++ b/SimpleQuiz/Utils/Session.php
@@ -74,6 +74,7 @@ class Session implements Base\ISession {
         if ($sql) {
             return $sql->data;
         }
+        return '';
     }
 
     public function write($id,$data)


### PR DESCRIPTION
ElanMan/simple-quiz#31

This patch fixes the warning on line 22 of Session.php under PHP 7.1 (tested in 7.1.11 under AMI Linux). Note that I did not experience the session_regenerate_id() issue in the referenced issue.

NB: SessionHandlerInterface requires the [read method](http://php.net/manual/en/sessionhandlerinterface.read.php) return a string for all values, else a PHP warning is issued. This commit allows the function to return an empty string, whereas it was previously not returning a value.